### PR TITLE
fix verify result output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 *.pub
 *.key
 .DS_Store
+tapestry-pipelines

--- a/cmd/tapestry/cli/tkn_verify.go
+++ b/cmd/tapestry/cli/tkn_verify.go
@@ -73,8 +73,9 @@ EXAMPLES
 }
 
 var (
-	colorRed   = "\033[31m"
-	colorGreen = "\033[32m"
+	colorRed   = "\033[0;31m"
+	colorGreen = "\033[0;32m"
+	reset      = "\033[0m"
 )
 
 //VerifyPipeline :
@@ -98,18 +99,18 @@ func VerifyPipeline(ctx context.Context, ko common.KeyVerifyOpts, recursive bool
 		for _, tc := range pc.TaskRefs {
 			taskResult := ""
 			if tc.Verified {
-				taskResult = fmt.Sprintf("%s %s (pipeline)", string(colorGreen), tc.Name)
+				taskResult = fmt.Sprintf("%s %s (task)", string(colorGreen), tc.Name)
 			} else {
-				taskResult = fmt.Sprintf("%s %s (pipeline)", string(colorRed), tc.Name)
+				taskResult = fmt.Sprintf("%s %s (task)", string(colorRed), tc.Name)
 			}
 			t := p.AddBranch(taskResult)
 			for _, sc := range tc.Steps {
-				s := t.AddBranch(fmt.Sprintf("%s (step)", sc.Name))
+				s := t.AddBranch(fmt.Sprintf("%s %s (step)", string(reset), sc.Name))
 				imgResult := ""
-				if tc.Verified {
-					imgResult = fmt.Sprintf("%s %s (pipeline)", string(colorGreen), sc.ImageRef)
+				if sc.Verified {
+					imgResult = fmt.Sprintf("%s %s (image)", string(colorGreen), sc.ImageRef)
 				} else {
-					imgResult = fmt.Sprintf("%s %s (pipeline)", string(colorRed), sc.ImageRef)
+					imgResult = fmt.Sprintf("%s %s (image)", string(colorRed), sc.ImageRef)
 				}
 				s.AddNode(imgResult)
 			}

--- a/pkg/sign/verifier.go
+++ b/pkg/sign/verifier.go
@@ -38,7 +38,7 @@ func (candidates *TknSignCandidates) Verify(ctx context.Context, verifyOpts comm
 	for idx, pc := range candidates.PipelinesSC {
 		imgRef := fmt.Sprintf("%s/%s:%s", verifyOpts.RegistryPath, pc.Name, verifyOpts.ImageTag)
 		if verified, err := verifyYamlFile(imgRef, verifyOpts.KeyRef, pc.Filepath); err != nil || !verified {
-			fmt.Fprintln(os.Stderr, err.Error())
+			// fmt.Fprintln(os.Stderr, err.Error())
 			candidates.PipelinesSC[idx].Verified = false
 		} else {
 			candidates.PipelinesSC[idx].Verified = true
@@ -47,13 +47,13 @@ func (candidates *TknSignCandidates) Verify(ctx context.Context, verifyOpts comm
 			imgRef := fmt.Sprintf("%s/%s:%s", verifyOpts.RegistryPath, tc.Name, verifyOpts.ImageTag)
 			if verified, err := verifyYamlFile(imgRef, verifyOpts.KeyRef, tc.Filepath); err != nil || !verified {
 				candidates.PipelinesSC[idx].TaskRefs[idy].Verified = false
-				fmt.Fprintln(os.Stderr, err.Error())
+				// fmt.Fprintln(os.Stderr, err.Error())
 			} else {
 				candidates.PipelinesSC[idx].TaskRefs[idy].Verified = true
 			}
 			for idz, sc := range tc.Steps {
 				if verified, err := verifyTaskImage(ctx, sc.ImageRef, verifyOpts.KeyRef); err != nil || !verified {
-					fmt.Fprintln(os.Stderr, err.Error())
+					// fmt.Fprintln(os.Stderr, err.Error())
 					candidates.PipelinesSC[idx].TaskRefs[idy].Steps[idz].Verified = false
 				} else {
 					candidates.PipelinesSC[idx].TaskRefs[idy].Steps[idz].Verified = true


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <nadgowda@us.ibm.com>

In the result output of `tapestry tin verify` fix the formatting 